### PR TITLE
The RSD aws is finished.

### DIFF
--- a/T_aws_rds/main.tf
+++ b/T_aws_rds/main.tf
@@ -1,0 +1,136 @@
+
+# Creates a database subnet group to specify the subnets that the RDS instance can use
+resource "aws_db_subnet_group" "my_db_subnet_group" {
+  name       = "my-db-subnet-group"
+  subnet_ids = [aws_subnet.T_private_1.id, aws_subnet.T_private_2.id]
+
+  tags = {
+    Name = "my-db-subnet-group"
+  }
+}
+
+
+# Creates a database security group to control the network access to the RDS instance
+resource "aws_security_group" "my_db_security_group" {
+  name_prefix = "T_db_s"
+  vpc_id      = aws_vpc.T_my_vpc_01.id
+
+
+  # Add ingress rule to allow traffic from an application server
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.T_my_ip] # Replace with the IP of the application server
+  }
+
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Add egress rule to allow outbound traffic
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+    prefix_list_ids = []
+  }
+
+  tags = {
+    Name = "${var.T_env_prefix}-sg"
+  }
+}
+
+# Creates a parameter group to configure database engine parameters
+resource "aws_db_parameter_group" "my_db_parameter_group" {
+  name   = "my-db-parameter-group"
+  family = "mysql8.0"
+  
+  parameter {
+    name  = "max_allowed_packet"
+    value = "67108864"
+  }
+}
+
+
+# Define the RDS instance
+resource "aws_db_instance" "my_db_instance" {
+  identifier                = "my-db"
+  allocated_storage         = 20
+  engine                    = "mysql"
+  engine_version            = "5.7"
+  instance_class            = "db.t2.micro"
+  db_name                   = "mydb"
+  username                  = "admin"
+  password                  = "mysecret"
+  storage_type              = "gp2"
+  backup_retention_period   = 7
+
+  # If set to true, a final snapshot is not created and the instance is immediately deleted.
+  skip_final_snapshot       = true 
+  final_snapshot_identifier = "my-final-db-snapshot"
+  db_subnet_group_name      = aws_db_subnet_group.my_db_subnet_group.name
+  vpc_security_group_ids    = [aws_security_group.my_db_security_group.id]
+
+  tags = {
+    Name = "My DB Instance"
+  }
+}
+
+
+# Create a new VPC
+resource "aws_vpc" "T_my_vpc_01" {
+  cidr_block = var.T_vpc_cidr_block
+
+  tags = {
+    Name = "${var.T_env_prefix}-VPC"
+  }
+}
+
+# Create two subnets in different Availability Zones in the VPC
+resource "aws_subnet" "T_private_1" {
+  cidr_block        = var.T_subnet_cidr_block_1
+  availability_zone = var.T_avail_zone_1
+  vpc_id            = aws_vpc.T_my_vpc_01.id
+
+  tags = {
+    Name = "${var.T_env_prefix}-Subnet-01"
+  }
+}
+
+resource "aws_subnet" "T_private_2" {
+  cidr_block        = var.T_subnet_cidr_block_2
+  availability_zone = var.T_avail_zone_2
+  vpc_id            = aws_vpc.T_my_vpc_01.id
+
+  tags = {
+    Name = "${var.T_env_prefix}-Subnet-02"
+  }
+}
+
+# Create an EC2 instance for testing
+resource "aws_instance" "T_instance_01" {
+  ami           = var.T_instance_ami
+  instance_type = var.T_instance_type
+  key_name      = aws_key_pair.T_ssh_key.key_name
+
+
+  subnet_id = aws_subnet.T_private_1.id
+
+  tags = {
+    Name = var.T_instance_name
+  }
+}
+
+# Create a key pair for ssh
+
+resource "aws_key_pair" "T_ssh_key" {
+  key_name   = "${var.T_env_prefix}_server_key"
+  public_key = file(var.T_key_name)
+}

--- a/T_aws_rds/provider.tf
+++ b/T_aws_rds/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region = "us-east-1"
+}

--- a/T_aws_rds/terraform.tfvars
+++ b/T_aws_rds/terraform.tfvars
@@ -1,0 +1,19 @@
+T_instance_ami        = "ami-006dcf34c09e50022"
+T_instance_type       = "t2.micro"
+T_instance_name       = "T_name_01"
+T_key_name            = "/home/tirdad/.ssh/id_rsa.pub"
+T_VPC_Name            = "T_VPC_Name"
+T_Subnet_Name         = "T_subnet_Name"
+T_env_prefix          = "T_Name"
+T_cidr_blocks         = ["0.0.0.0/0"]
+T_cidr_block          = "0.0.0.0/0"
+T_vpc_cidr_block      = "10.0.0.0/16"
+T_subnet_cidr_block_1 = "10.0.1.0/24"
+T_subnet_cidr_block_2 = "10.0.2.0/24"
+T_avail_zone_1        = "us-east-1a"
+T_avail_zone_2        = "us-east-1b"
+T_SG_Name             = "T_SG_Name"
+T_my_ip               = "192.168.0.0/24" # The IP is from this website: https://www.whatsmyip.org/
+
+
+

--- a/T_aws_rds/variable.tf
+++ b/T_aws_rds/variable.tf
@@ -1,0 +1,18 @@
+
+variable "T_instance_ami" {}
+variable "T_instance_type" {}
+variable "T_instance_name" {}
+variable "T_key_name" {}
+variable "T_VPC_Name" {}
+variable "T_Subnet_Name" {}
+variable "T_env_prefix" {}
+variable "T_cidr_blocks" {}
+variable "T_cidr_block" {}
+variable "T_vpc_cidr_block" {}
+variable "T_subnet_cidr_block_1" {}
+variable "T_subnet_cidr_block_2" {}
+variable "T_avail_zone_1" {}
+variable "T_avail_zone_2" {}
+variable "T_SG_Name" {}
+variable "T_my_ip" {}
+


### PR DESCRIPTION
To create an RDS instance, you would typically need the following:

1. A VPC with at least two subnets in different availability zones
2. A security group to control inbound and outbound traffic to the RDS instance
3. An RDS subnet group to specify which subnets the RDS instance can use
4. A parameter group to configure the database engine settings
5. An optional option group to enable additional features
6. An IAM role with permissions to manage the RDS instance
7. The desired database engine and version
8. The desired instance class and storage capacity
9. The desired database name, username, and password

Keep in mind that the specific requirements may vary depending on your use case and environment.